### PR TITLE
Fix refreshUser causing page reload

### DIFF
--- a/frontend/src/components/auth/EmailChangeVerificationPanel.tsx
+++ b/frontend/src/components/auth/EmailChangeVerificationPanel.tsx
@@ -23,12 +23,12 @@ const EmailChangeVerificationPanel: React.FC = () => {
     }
 
     verifyEmailChange(token)
-      .then(async () => {
-        setSuccess(true);
-        setMessage("Email verified successfully! You may now close this tab.");
-        try {
-          await refreshUser();
-        } catch {/* ignore */}
+        .then(async () => {
+          setSuccess(true);
+          setMessage("Email verified successfully! You may now close this tab.");
+          try {
+            await refreshUser(true);
+          } catch {/* ignore */}
         // notify other tabs immediately
         const channel = new BroadcastChannel("emailVerified");
         channel.postMessage("verified");

--- a/frontend/src/components/dashboard/panels/settings/ProfileSettings.tsx
+++ b/frontend/src/components/dashboard/panels/settings/ProfileSettings.tsx
@@ -46,7 +46,7 @@ export default function ProfileSettings() {
             const msg = `✅ Username changed to ${clean}`;
             emit("username", msg);
             await new Promise(res => setTimeout(res, 1000)); // <-- Try adding this
-            await refreshUser();
+            await refreshUser(true);
         } catch (err) {
             let msg = "Username update failed";
             const axiosErr = err as AxiosErrorLike;
@@ -71,7 +71,7 @@ export default function ProfileSettings() {
       await changeEmail(newEmail);
       emit("email", `Verification email sent to ${newEmail}. Please check your inbox.`);
       emit("auth_success", "✅ Verification email sent to your new address. Please click the link to confirm.");
-      await refreshUser();
+        await refreshUser(true);
     } catch (err) {
       let msg = "Email update failed";
       const axiosErr = err as AxiosErrorLike;
@@ -86,7 +86,7 @@ export default function ProfileSettings() {
     try {
       await cancelPendingEmail();
       emit("email", "Pending email change cancelled.");
-      await refreshUser();
+        await refreshUser(true);
     } catch {
       emit("auth_error", "Could not cancel pending email.");
     }
@@ -99,7 +99,7 @@ export default function ProfileSettings() {
       await changePassword(oldPass, newPass);
       emit("password", "Password updated successfully.");
       emit("auth_success", "✅ Password changed.");
-      await refreshUser();
+        await refreshUser(true);
     } catch {
       emit("auth_error", "Password change failed.");
     }
@@ -115,7 +115,7 @@ export default function ProfileSettings() {
       await changePin(oldPin, newPin);
       emit("pin", "PIN updated successfully.");
       emit("auth_success", "✅ PIN changed.");
-      await refreshUser();
+        await refreshUser(true);
     } catch {
       emit("auth_error", "PIN change failed.");
     }

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -51,7 +51,7 @@ interface AuthContextType {
   pinVerified: boolean;
   
 
-  refreshUser: () => Promise<UserProfile>;
+  refreshUser: (silent?: boolean) => Promise<UserProfile>;
 
   register: (data: RegisterData) => Promise<UserProfile>;
   login: (username: string, password: string) => Promise<UserProfile>;
@@ -155,16 +155,19 @@ function useProvideAuth(): AuthContextType {
   const isValidToken = (t: string): boolean => t.split(".").length === 3;
 
   // Refresh user data
-  const refreshUser = useCallback(async (): Promise<UserProfile> => {
-    setLoading(true);
-    try {
-      const profile = await getProfile();
-      setUser(profile);
-      return profile;
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const refreshUser = useCallback(
+    async (silent = false): Promise<UserProfile> => {
+      if (!silent) setLoading(true);
+      try {
+        const profile = await getProfile();
+        setUser(profile);
+        return profile;
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    []
+  );
 
   // Register
   const register = useCallback(


### PR DESCRIPTION
## Summary
- keep dashboard visible when refreshing user info
- avoid flicker in MycoCore logs after email or profile updates

## Testing
- `pytest -q` *(fails: ValidationError and missing functions)*

------
https://chatgpt.com/codex/tasks/task_e_68773119e094832cb335fc373ceb398b